### PR TITLE
Add teacher admin mode for protected enrollment changes

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher-authenticated sign up and unregister for activities
+- Student-safe view mode (students can view participants but cannot modify enrollments)
 
 ## Getting Started
 
@@ -30,7 +31,15 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Teacher login (returns token)                                       |
+| POST   | `/auth/logout`                                                    | Teacher logout (requires `X-Teacher-Token`)                         |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity (teacher only)                              |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity (teacher only)                          |
+
+## Teacher Credentials
+
+Teacher credentials are stored in `src/teachers.json` and validated by the backend.
+Use any configured username/password pair to log in from the top-right user icon in the web app.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -30,8 +30,24 @@ class TeacherLoginRequest(BaseModel):
 
 def load_teacher_credentials() -> dict[str, str]:
     teachers_file = current_dir / "teachers.json"
-    with open(teachers_file, "r", encoding="utf-8") as file:
-        payload = json.load(file)
+    try:
+        with open(teachers_file, "r", encoding="utf-8") as file:
+            payload = json.load(file)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"Startup configuration error: required teacher credentials file "
+            f"'{teachers_file}' was not found."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Startup configuration error: teacher credentials file "
+            f"'{teachers_file}' contains invalid JSON: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"Startup configuration error: could not read teacher credentials "
+            f"file '{teachers_file}': {exc}"
+        ) from exc
 
     teachers: dict[str, str] = {}
     for teacher in payload.get("teachers", []):

--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +21,40 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+class TeacherLoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teacher_credentials() -> dict[str, str]:
+    teachers_file = current_dir / "teachers.json"
+    with open(teachers_file, "r", encoding="utf-8") as file:
+        payload = json.load(file)
+
+    teachers: dict[str, str] = {}
+    for teacher in payload.get("teachers", []):
+        username = teacher.get("username")
+        password = teacher.get("password")
+        if username and password:
+            teachers[username] = password
+    return teachers
+
+
+teacher_credentials = load_teacher_credentials()
+active_teacher_tokens: dict[str, str] = {}
+
+
+def require_teacher(
+    x_teacher_token: str | None = Header(default=None, alias="X-Teacher-Token")
+) -> str:
+    if not x_teacher_token or x_teacher_token not in active_teacher_tokens:
+        raise HTTPException(
+            status_code=401,
+            detail="Teacher authentication is required for this action"
+        )
+    return active_teacher_tokens[x_teacher_token]
 
 # In-memory activity database
 activities = {
@@ -88,8 +125,36 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def teacher_login(credentials: TeacherLoginRequest):
+    stored_password = teacher_credentials.get(credentials.username)
+    if not stored_password or stored_password != credentials.password:
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    token = secrets.token_urlsafe(24)
+    active_teacher_tokens[token] = credentials.username
+    return {
+        "message": "Teacher logged in successfully",
+        "token": token,
+        "username": credentials.username
+    }
+
+
+@app.post("/auth/logout")
+def teacher_logout(x_teacher_token: str | None = Header(default=None, alias="X-Teacher-Token")):
+    if not x_teacher_token or x_teacher_token not in active_teacher_tokens:
+        raise HTTPException(status_code=401, detail="Invalid teacher session")
+
+    del active_teacher_tokens[x_teacher_token]
+    return {"message": "Teacher logged out successfully"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    _: str = Depends(require_teacher)
+):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +176,11 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    _: str = Depends(require_teacher)
+):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,7 +2,55 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const teacherRequiredMessage = document.getElementById("teacher-required-message");
+  const teacherStatus = document.getElementById("teacher-status");
+  const userLoginBtn = document.getElementById("user-login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginBtn = document.getElementById("close-login-btn");
+  const loginForm = document.getElementById("login-form");
   const messageDiv = document.getElementById("message");
+  let teacherToken = localStorage.getItem("teacherToken");
+  let teacherUsername = localStorage.getItem("teacherUsername");
+
+  function isTeacherLoggedIn() {
+    return Boolean(teacherToken);
+  }
+
+  function showMessage(text, type = "info") {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    if (isTeacherLoggedIn()) {
+      teacherStatus.textContent = `Teacher: ${teacherUsername}`;
+      userLoginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      signupForm.classList.remove("hidden");
+      teacherRequiredMessage.classList.add("hidden");
+    } else {
+      teacherStatus.textContent = "Student view";
+      userLoginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      signupForm.classList.add("hidden");
+      teacherRequiredMessage.classList.remove("hidden");
+    }
+  }
+
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +60,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +79,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacherLoggedIn()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,39 +133,100 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
+        if (response.status === 401) {
+          handleTeacherLogout();
+          openLoginModal();
+        }
+      }
+    } catch (error) {
+      showMessage("Failed to unregister. Please try again.", "error");
+      console.error("Error unregistering:", error);
+    }
+  }
+
+  async function handleTeacherLogin(event) {
+    event.preventDefault();
+    const username = document.getElementById("teacher-username").value;
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
       }
 
-      messageDiv.classList.remove("hidden");
+      teacherToken = result.token;
+      teacherUsername = result.username;
+      localStorage.setItem("teacherToken", teacherToken);
+      localStorage.setItem("teacherUsername", teacherUsername);
 
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      updateAuthUI();
+      closeLoginModal();
+      showMessage(`Logged in as ${teacherUsername}`, "success");
+      fetchActivities();
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
-      console.error("Error unregistering:", error);
+      showMessage("Login request failed", "error");
+      console.error("Error logging in:", error);
+    }
+  }
+
+  async function handleTeacherLogout() {
+    try {
+      if (teacherToken) {
+        await fetch("/auth/logout", {
+          method: "POST",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
+        });
+      }
+    } catch (error) {
+      console.error("Error logging out:", error);
+    } finally {
+      teacherToken = null;
+      teacherUsername = null;
+      localStorage.removeItem("teacherToken");
+      localStorage.removeItem("teacherUsername");
+      updateAuthUI();
+      fetchActivities();
+      showMessage("Logged out", "info");
     }
   }
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!isTeacherLoggedIn()) {
+      showMessage("Teacher login is required", "error");
+      openLoginModal();
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +238,45 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "X-Teacher-Token": teacherToken,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
+        if (response.status === 401) {
+          handleTeacherLogout();
+          openLoginModal();
+        }
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userLoginBtn.addEventListener("click", openLoginModal);
+  closeLoginBtn.addEventListener("click", closeLoginModal);
+  loginForm.addEventListener("submit", handleTeacherLogin);
+  logoutBtn.addEventListener("click", handleTeacherLogout);
+
+  loginModal.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      closeLoginModal();
+    }
+  });
+
   // Initialize app
+  updateAuthUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,9 +8,40 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-top-row">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="user-menu">
+          <span id="teacher-status" class="teacher-status">Student view</span>
+          <button id="user-login-btn" class="user-login-btn" type="button" aria-label="Teacher login">
+            👤 Login
+          </button>
+          <button id="logout-btn" class="logout-btn hidden" type="button">Logout</button>
+        </div>
+      </div>
     </header>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required placeholder="password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="close-login-btn" class="secondary-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -23,6 +54,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-required-message" class="info-text hidden">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,30 @@ header h1 {
   margin-bottom: 10px;
 }
 
+.header-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.user-menu {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.teacher-status {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.user-login-btn,
+.logout-btn {
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;
@@ -55,6 +79,46 @@ section h3 {
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
   color: #1a237e;
+}
+
+.info-text {
+  margin-bottom: 12px;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 430px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.secondary-btn {
+  background-color: #666;
+}
+
+.secondary-btn:hover {
+  background-color: #555;
 }
 
 .activity-card {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher.alex",
+      "password": "Mergington123!"
+    },
+    {
+      "username": "teacher.samara",
+      "password": "Activities456!"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR implements Issue #5 by adding a teacher login flow and restricting enrollment edits to authenticated teachers.

## What changed
- Added teacher authentication endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
- Added header-based protection (`X-Teacher-Token`) for:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added credential storage file:
  - `src/teachers.json`
- Updated frontend with:
  - top-right user login button
  - teacher login modal
  - logout flow
  - student-safe view (students can view participants but cannot modify enrollments)
- Updated `src/README.md` with new auth flow and endpoints.

## Why
Students were able to remove each other from activities. This introduces role-based behavior aligned with the issue request: only logged-in teachers can register/unregister students.

Closes #5